### PR TITLE
[修正] ページレイアウト

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -42,6 +42,7 @@ https://github.com/pages-themes/dinky
               <li><a href="{{ '/note/linux/git' | relative_url }}">Git</a></li>
               <li><a href="{{ '/note/linux/vim' | relative_url }}">Vim</a></li>
               <li><a href="{{ '/note/linux/ubuntu' | relative_url }}">Ubuntu</a></li>
+            </ul>
           </li>
           <li><a href="{{ '/note/windows' | relative_url }}">Windows</a></li>
           <li><a href="{{ '/note/general' | relative_url }}">全般</a></li>


### PR DESCRIPTION
# 概要

レイアウトが崩れてたので、修正

ついでにデフォルトのロケールも ja_JP に変更