### PR TITLE
[修正] Git ページの画像リンク

### DIFF
--- a/note/linux/git/refBook_Wakaba.md
+++ b/note/linux/git/refBook_Wakaba.md
@@ -341,7 +341,7 @@ GitHub やその他多数の Web 企業で採用されている、シンプル�
 
 ![pull](img/pull.png)
 
-![fetch&merge](img/fetch&merge.png)
+![fetch&merge](img/fetchAndMerge.png)
 
 
 ## <a id="conflict"></a> コンフリクト


### PR DESCRIPTION
# 概要

#15 で画像のファイル名を変更したが、ページ内リンクのファイル名変更を忘れてたので修正